### PR TITLE
Integration of the ObjectIdentityRetrievalStrategy service

### DIFF
--- a/Domain/AbstractAclManager.php
+++ b/Domain/AbstractAclManager.php
@@ -15,6 +15,7 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Role\RoleInterface;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Acl\Model\ObjectIdentityRetrievalStrategyInterface;
 use Problematic\AclManagerBundle\Model\PermissionContextInterface;
 use Problematic\AclManagerBundle\Model\AclManagerInterface;
 
@@ -28,11 +29,13 @@ abstract class AbstractAclManager implements AclManagerInterface
 
     private $aclProvider;
     private $securityContext;
+    private $objectIdentityRetrievalStrategy;
 
-    public function __construct(MutableAclProviderInterface $aclProvider, SecurityContextInterface $securityContext)
+    public function __construct(MutableAclProviderInterface $aclProvider, SecurityContextInterface $securityContext, ObjectIdentityRetrievalStrategyInterface $objectIdentityRetrievalStrategy)
     {
         $this->aclProvider = $aclProvider;
         $this->securityContext = $securityContext;
+        $this->objectIdentityRetrievalStrategy = $objectIdentityRetrievalStrategy;
     }
     
     /**
@@ -51,6 +54,14 @@ abstract class AbstractAclManager implements AclManagerInterface
         return $this->securityContext;
     }
 
+    /**
+     * @return ObjectIdentityRetrievalStrategyInterface
+     */
+    protected function getObjectIdentityRetrievalStrategy()
+    {
+    	return $this->objectIdentityRetrievalStrategy;
+    }
+    
     /**
      * Loads an ACL from the ACL provider, first by attempting to create, then finding if it already exists
      * 

--- a/Domain/AclManager.php
+++ b/Domain/AclManager.php
@@ -44,7 +44,7 @@ class AclManager extends AbstractAclManager
             $securityIdentity = $this->getUser();
         }
         $context = $this->doCreatePermissionContext($type, $securityIdentity, $mask);
-        $oid = ObjectIdentity::fromDomainObject($domainObject);
+        $oid = $this->getObjectIdentityRetrievalStrategy()->getObjectIdentity($domainObject);
         $acl = $this->doLoadAcl($oid);
         $this->doApplyPermission($acl, $context, $replace_existing);
         
@@ -87,7 +87,7 @@ class AclManager extends AbstractAclManager
             $securityIdentity = $this->getUser();
         }
         $context = $this->doCreatePermissionContext($type, $securityIdentity, $mask);
-        $oid = ObjectIdentity::fromDomainObject($domainObject);
+        $oid = $this->getObjectIdentityRetrievalStrategy()->getObjectIdentity($domainObject);
         $acl = $this->doLoadAcl($oid);
         $this->doRevokePermission($acl, $context);
         $this->getAclProvider()->updateAcl($acl);
@@ -117,7 +117,7 @@ class AclManager extends AbstractAclManager
             $securityIdentity = $this->getUser();
         }
         $securityIdentity = $this->doCreateSecurityIdentity($securityIdentity);
-        $oid = ObjectIdentity::fromDomainObject($domainObject);
+        $oid = $this->getObjectIdentityRetrievalStrategy()->getObjectIdentity($domainObject);
         $acl = $this->doLoadAcl($oid);
         $this->doRevokeAllPermissions($acl, $securityIdentity, $type);
         $this->getAclProvider()->updateAcl($acl);
@@ -129,7 +129,7 @@ class AclManager extends AbstractAclManager
     {
         $oids = array();
         foreach ($objects as $object) {
-            $oid = ObjectIdentity::fromDomainObject($object);
+            $oid = $this->getObjectIdentityRetrievalStrategy()->getObjectIdentity($object);
             $oids[] = $oid;
         }
         
@@ -140,7 +140,7 @@ class AclManager extends AbstractAclManager
     
     public function deleteAclFor($domainObject)
     {
-        $oid = ObjectIdentity::fromDomainObject($domainObject);
+        $oid = $this->getObjectIdentityRetrievalStrategy()->getObjectIdentity($domainObject);
         $this->getAclProvider()->deleteAcl($oid);
         
         return $this;

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -4,3 +4,4 @@ services:
         arguments:
             aclProvider: "@security.acl.provider"
             securityContext: "@security.context"
+            objectIdentityRetrievalStrategy: "@security.acl.object_identity_retrieval_strategy"


### PR DESCRIPTION
Use ObjectIdentityRetrievalStrategy service instead of ObjectIdentity::fromDomainObject static method.
This solution is more flexible and allow to override the ObjectIdentityRetrievalStrategy.
For exemple, I'm using this OidRetrievalStrategy -> http://jonathaningram.com.au/2012/01/13/overriding-the-objectidentityretrievalstrategy-to-check-if-a-domain-object-is-a-doctrine-proxy/

This architecture allows this kind of operation :

```
$aclManager->preloadAcls($product->getComments());
```
