### PR TITLE
Fixing trailing comma in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         {
             "name": "Derek Stobbe",
             "email": "djstobbe@gmail.com"
-        },
+        }
     ],
     "require": {
         "php": ">=5.3.2",


### PR DESCRIPTION
This fixes a syntax error in composer.json (trailing comma in authors).
