### PR TITLE
Fix for filtering preloaded acl by sids

### DIFF
--- a/Domain/AclManager.php
+++ b/Domain/AclManager.php
@@ -188,7 +188,7 @@ class AclManager extends AbstractAclManager
         return $this;
     }
 
-    public function preloadAcls($objects)
+    public function preloadAcls($objects, $identities = array())
     {
         $oids = array();
         foreach ($objects as $object) {
@@ -196,7 +196,13 @@ class AclManager extends AbstractAclManager
             $oids[] = $oid;
         }
 
-        $acls = $this->getAclProvider()->findAcls($oids); // todo: do we need to do anything with these?
+        $sids = array();
+        foreach ($identities as $identity) {
+            $sid = $this->doCreateSecurityIdentity($identity);
+            $sids[] = $sid;
+        }
+
+        $acls = $this->getAclProvider()->findAcls($oids, $sids); // todo: do we need to do anything with these?
 
         return $acls;
     }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,6 +1,9 @@
+parameters:
+    problematic.acl_manager.class: Problematic\AclManagerBundle\Domain\AclManager
+
 services:
     problematic.acl_manager:
-        class: Problematic\AclManagerBundle\Domain\AclManager
+        class: %problematic.acl_manager.class%
         arguments:
             aclProvider: "@security.acl.provider"
             securityContext: "@security.context"


### PR DESCRIPTION
Added possibility to pass security identities to acl provider.
Moved acl manager service class to parameter to enable service extending.
